### PR TITLE
refactor: remove SHELL = zsh in all Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SHELL = zsh
-
 benchmark_directory = benchmarks
 
 gnark_directory = gnark

--- a/circom/Makefile
+++ b/circom/Makefile
@@ -1,5 +1,3 @@
-SHELL = zsh
-
 all: sudoku cubic
 
 sudoku:

--- a/gnark/Makefile
+++ b/gnark/Makefile
@@ -1,5 +1,3 @@
-SHELL = zsh
-
 directory = github.com/tumberger/zk-compilers/gnark
 
 .PHONY = test


### PR DESCRIPTION
zsh may not be the default shell for certain systems - it would probably be preferable to not specify zsh, since by default Makefiles will use `/bin/sh` which is more portable: https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html