### PR TITLE
feat: initial support for jellyfish benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,13 @@ benchmark-toy-gnark:
 	$(info --------------------------------------------)
 	python3 -m _scripts.reader --config _input/config/gnark/config_all_toy.json  
 
+benchmark-toy-jellyfish:
+	$(info --------------------------------------------)
+	$(info --------- JELLYFISH TOY BENCHMARKS ---------)
+	$(info --------------------------------------------)
+	python3 -m _scripts.reader --config _input/config/jellyfish/config_all_toy.json  
+
+
 benchmark-hash:
 	python3 -m _scripts.reader --config _input/config/gnark/config_hash.json  
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ benchmark-toy-jellyfish:
 	$(info --------------------------------------------)
 	$(info --------- JELLYFISH TOY BENCHMARKS ---------)
 	$(info --------------------------------------------)
-	python3 -m _scripts.reader --config _input/config/jellyfish/config_all_toy.json  
+	rm benchmarks/jellyfish/*; python3 -m _scripts.reader --config _input/config/jellyfish/config_all_toy.json  
 
 
 benchmark-hash:

--- a/_input/config/jellyfish/config_all_toy.json
+++ b/_input/config/jellyfish/config_all_toy.json
@@ -1,0 +1,27 @@
+{
+    "project": "jellyfish",
+    "project_url": "https://github.com/EspressoSystems/jellyfish",
+    "category": "circuit",
+    "count": 10,
+    "payload": {
+        "backend": [
+            "plonk"
+        ],
+        "curves": [
+            "bls12_381",
+            "bls12_377",
+            "bn254",
+            "bw6_761"
+        ], 
+        "circuits": {
+            "cubic": {
+                "input_path": "_input/circuit/cubic"
+            }
+        },
+        "algorithm": [
+            "compile"
+
+        ],
+        "custom": {}
+    }    
+}

--- a/_scripts/reader/helper.py
+++ b/_scripts/reader/helper.py
@@ -7,6 +7,8 @@ MAIN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 BENCHMARKS_DIR = os.path.join(MAIN_DIR, "benchmarks")
 # GNARK PATHS
 GNARK_DIR = os.path.join(MAIN_DIR, "gnark")
+# JELLYFISH PATHS
+JELLYFISH_DIR = os.path.join(MAIN_DIR, "jellyfish")
 # CIRCOM PATHS
 CIRCOM_DIR = os.path.join(MAIN_DIR, "circom")
 CIRCOM_BENCHMAKR_DIR = os.path.join(BENCHMARKS_DIR, "circom")

--- a/_scripts/reader/process_circuit.py
+++ b/_scripts/reader/process_circuit.py
@@ -63,6 +63,27 @@ def build_command_circom(payload, count):
     return command
 
 
+def build_command_jellyfish(payload, count):
+    """
+    Build the command to invoke the gnark ZKP-framework given the payload
+    """
+    
+    if payload.backend is not None and payload.curves is not None:
+        commands = [f"cargo run --release -- --backend {backend} --circuit {circ} --input {inp} --curve {curve} --count {count} --op {op}\n"
+                    for backend in payload.backend
+                    for curve in payload.curves
+                    for circ, input_path in payload.circuit.items()
+                    for inp in helper.get_all_input_files(input_path)
+                    for op in payload.operation]
+
+        # Join the commands into a single string
+        command = "".join(commands)
+        # Prepend the command to change the working directory to the gnark directory
+        command = f"cd {helper.JELLYFISH_DIR}; {command}"
+    else:
+        raise ValueError("Missing payload fields for circuit mode")
+    return command
+
 def default_case():
     raise ValueError("Framework not integrated into the benchmarking framework!")
 
@@ -70,6 +91,7 @@ def default_case():
 # List ZKP-frameworks in the zk-Harness
 projects = {
     "gnark":    build_command_gnark,
+    "jellyfish": build_command_jellyfish,
     "circom/snarkjs":   build_command_circom
 }
 

--- a/benchmarks/jellyfish/jellyfish_plonk_cubic.csv
+++ b/benchmarks/jellyfish/jellyfish_plonk_cubic.csv
@@ -1,0 +1,5 @@
+framework,category,backend,curve,circuit,input,operation,nbConstraints,nbSecret,nbPublic,ram,time(ms),proofSize,nbPhysicalCores,nbLogicalCores,count,cpu
+jellyfish,circuit,plonk,bls12_381,cubic,_input/circuit/cubic/input_1.json,compile,7,10,1,0,1,0,10,12,10,12th Gen Intel(R) Core(TM) i7-1255U
+jellyfish,circuit,plonk,bls12_377,cubic,_input/circuit/cubic/input_1.json,compile,7,10,1,0,1,0,10,12,10,12th Gen Intel(R) Core(TM) i7-1255U
+jellyfish,circuit,plonk,bn254,cubic,_input/circuit/cubic/input_1.json,compile,7,10,1,0,1,0,10,12,10,12th Gen Intel(R) Core(TM) i7-1255U
+jellyfish,circuit,plonk,bw6_761,cubic,_input/circuit/cubic/input_1.json,compile,7,10,1,0,1,0,10,12,10,12th Gen Intel(R) Core(TM) i7-1255U

--- a/jellyfish/Cargo.toml
+++ b/jellyfish/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "jellyfish"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+ark-bls12-377 = "0.4.0"
+ark-bls12-381 = "0.4.0"
+ark-bn254 = "0.4.0"
+ark-bw6-761 = "0.4.0"
+ark-ec = "0.4.0"
+ark-ff = { version = "0.4.0", features = [ "asm" ] }
+ark-poly = "0.4.0"
+ark-serialize = "0.4.0"
+ark-std = { version = "0.4.0", default-features = false }
+clap = { version = "4.2.2", features = ["derive"] }
+csv = "1.2"
+jf-plonk = { git = "https://github.com/EspressoSystems/jellyfish", version = "0.3.0" }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", version = "0.3.0" }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", version = "0.3.0" }
+serde = "1.0.160"
+serde_json = "1.0"
+sysinfo = "0.28"
+num_cpus = "1.15"
+
+[dev-dependencies]
+ark-ed-on-bls12-377 = "0.4.0"
+ark-ed-on-bls12-381 = "0.4.0"
+ark-ed-on-bls12-381-bandersnatch = "0.4.0"
+ark-ed-on-bn254 = "0.4.0"

--- a/jellyfish/src/main.rs
+++ b/jellyfish/src/main.rs
@@ -1,0 +1,214 @@
+use anyhow::Result;
+use ark_bw6_761::Fr as Fr761;
+use ark_ff::PrimeField;
+use clap::Parser;
+use jf_plonk::errors::PlonkError;
+use jf_relation::{Circuit, PlonkCircuit};
+use serde::{Deserialize, Serialize};
+use std::{path::PathBuf, time::Instant};
+use sysinfo::{CpuExt, SystemExt};
+
+pub const FRAMEWORK: &str = "jellyfish";
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Backend to use.
+    ///
+    /// This input should usually be provided by process_circuit.py, under _scripts.
+    #[arg(short, long)]
+    backend: String,
+    /// Type of circuit to benchmark against.
+    ///
+    /// This input should usually be provided by process_circuit.py, under _scripts.
+    #[arg(long)]
+    circuit: String,
+    /// Curve to use.
+    ///
+    /// This input should usually be provided by process_circuit.py, under _scripts.
+    #[arg(long)]
+    curve: String,
+    /// Path(s) to the JSON inputs used.
+    ///
+    /// This input should usually be provided by process_circuit.py, under _scripts.
+    #[arg(long)]
+    input: String,
+    /// Kind of operation to run.
+    ///
+    /// This input should usually be provided by process_circuit.py, under _scripts.
+    #[arg(long)]
+    op: Operation,
+    /// Number of times to run.
+    ///
+    /// This input should usually be provided by process_circuit.py, under _scripts.
+    #[arg(long)]
+    count: usize,
+}
+
+fn compile_bench<F: PrimeField>(
+    x: u32,
+    y: u32,
+    count: usize,
+) -> Result<PlonkCircuit<F>, PlonkError> {
+    for _ in 0..count - 1 {
+        let _: PlonkCircuit<F> = cubic_circuit(x, y).unwrap();
+    }
+
+    cubic_circuit::<F>(x, y)
+}
+
+fn cubic_circuit<F: PrimeField>(x: u32, y: u32) -> Result<PlonkCircuit<F>, PlonkError> {
+    let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
+
+    // Setup required variables
+    let a = circuit.create_variable(F::from(x)).unwrap();
+    let _y = circuit.create_public_variable(F::from(y)).unwrap();
+    let five = circuit.create_variable(F::from(5u32)).unwrap();
+    let b = circuit.create_variable(F::from(x)).unwrap();
+
+    // Starting here, we build: x^3 + x + 5 == y
+    // x = x * x * x
+    let x_to_two = circuit.mul(a, b).unwrap();
+    let x_to_three = circuit.mul(a, x_to_two).unwrap();
+
+    // e = x^3 + x
+    let e = circuit.add(a, x_to_three).unwrap();
+
+    // f = x^3 + x + 5
+    let _f = circuit.add(e, five).unwrap();
+
+    Ok(circuit)
+}
+
+/// A row of benchmark results within the CSV log.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Record {
+    framework: String,
+    category: Category,
+    backend: String,
+    curve: String,
+    circuit: String,
+    input: PathBuf,
+    operation: Operation,
+    nb_constraints: String,
+    nb_secret: String,
+    nb_public: String,
+    ram: usize,
+    proof_size: usize,
+    /// Time (in milliseconds) for the operation to finish.
+    #[serde(rename(serialize = "time(ms)"))]
+    time: String,
+    nb_physical_cores: usize,
+    nb_logical_cores: usize,
+    count: usize,
+    cpu: String,
+}
+
+/// Input for cubic curve.
+#[allow(non_snake_case)]
+#[derive(Debug, Deserialize)]
+struct CubicInput {
+    X: String,
+    Y: String,
+}
+
+#[derive(Debug, Serialize, Clone, clap::ValueEnum)]
+#[serde(rename_all = "camelCase")]
+enum Operation {
+    Compile,
+    Setup,
+    Witness,
+    Prove,
+    Verify,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum Category {
+    Circuit,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    println!(
+        "Running:\n backend: {}\n circuit: {}\n curve: {}\n count: {} input: {}\n",
+        args.backend, args.circuit, args.curve, args.count, args.input
+    );
+
+    let mut writer =
+        csv::Writer::from_path("../benchmarks/jellyfish/jellyfish_plonk_cubic.csv").unwrap();
+
+    let file = format!("../{}", args.input);
+    let input = std::fs::read_to_string(file).unwrap();
+    let input: CubicInput = serde_json::de::from_str(&input).unwrap();
+
+    let x = input.X.parse().ok().unwrap();
+    let y = input.Y.parse().ok().unwrap();
+
+    match args.op {
+        Operation::Compile => {
+            let start = Instant::now();
+            let cs: PlonkCircuit<Fr761> = compile_bench(x, y, args.count).unwrap();
+            let end = start.elapsed().as_secs_f32() * 1000.0;
+            println!("end: {}", end);
+
+            let system = sysinfo::System::new_all();
+            let record = Record {
+                framework: FRAMEWORK.to_string(),
+                category: Category::Circuit,
+                backend: args.backend.to_string(),
+                curve: args.curve.to_string(),
+                circuit: args.circuit.to_string(),
+                input: args.input.into(),
+                operation: args.op,
+                nb_constraints: cs.num_gates().to_string(),
+                nb_secret: cs.num_vars().to_string(),
+                nb_public: cs.num_inputs().to_string(),
+                ram: Default::default(),        // TODO: add memory usage
+                proof_size: Default::default(), // TODO: add proof_size
+                time: end.to_string(),
+                nb_physical_cores: num_cpus::get_physical(),
+                nb_logical_cores: num_cpus::get(),
+                count: args.count,
+                cpu: system.global_cpu_info().brand().to_string(),
+            };
+
+            writer.serialize(record).unwrap();
+            writer.flush().unwrap();
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_bls12_377::Fq as Fq377;
+    use ark_ed_on_bls12_377::Fq as FqEd377;
+    use ark_ed_on_bls12_381::Fq as FqEd381;
+    use ark_ed_on_bn254::Fq as FqEd254;
+    use jf_relation::errors::CircuitError;
+
+    use super::*;
+
+    #[test]
+    fn test_cubic() -> Result<(), CircuitError> {
+        test_cubic_helper::<FqEd254>()?;
+        test_cubic_helper::<FqEd377>()?;
+        test_cubic_helper::<FqEd381>()?;
+        test_cubic_helper::<Fq377>()
+    }
+
+    fn test_cubic_helper<F: PrimeField>() -> Result<(), CircuitError> {
+        let circuit: PlonkCircuit<F> = cubic_circuit(1u32, 1u32).unwrap();
+        // 2 mul gates, 2 additional, 2 constant gates
+        assert_eq!(circuit.num_gates(), 7);
+        // Check the number of public inputs:
+        assert_eq!(circuit.num_inputs(), 1);
+        // circuit.enforce_equal(result, f).unwrap();
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR will add:

- a prototype `clap` app written in Rust that uses `jellyfish` to carry out operations for benchmarking,
- a `cubic` circuit to start off with at first,
- updates to the Python script that drives the execution of the above Rust program.

