### PR TITLE
chore: correct typos docs

### DIFF
--- a/frameworks/circom/README.md
+++ b/frameworks/circom/README.md
@@ -1,7 +1,7 @@
 # Circom Compiler / snarkjs
 
 [Circom](https://github.com/iden3/circom) is a comiler (Hardware Description Language / HDL) written in Rust.
-The compiler outputs the representation of the circuit as R1CS. Successively, one can apply the respective proof system.
+The compiler outputs the representation of the circuit as R1CS. Subsequently, one can apply the respective proof system.
 Circom's output can be used via a backend (typically using [snarkjs](https://github.com/iden3/snarkjs)).
 
 ## Installation

--- a/frameworks/gnark/TUTORIAL.md
+++ b/frameworks/gnark/TUTORIAL.md
@@ -4,7 +4,7 @@ To add a new circuit please follow the next steps.
 
 ## Adding a new circuit
 
-1. Add the circuit source code: You should should add sour source code file(s) in a new directory named `circuits/<category>/<circuit_name>.go`.
+1. Add the circuit source code: You should add sour source code file(s) in a new directory named `circuits/<category>/<circuit_name>.go`.
 If you need to use any external libraries please include them in your project directory.
 
 2. Adding a test compliant with the gnark testing suite: Each new circuit should be tested with a test compliant with the gnark testing suite.


### PR DESCRIPTION
I reviewed the entire repository, no more typos found in docs. 
Hope this helps streamline the project!
Best regards,
Bilogweb3